### PR TITLE
Change depreciated os method call.

### DIFF
--- a/lib/system-font.js
+++ b/lib/system-font.js
@@ -8,7 +8,7 @@ var child_process = require('child_process');
 var mv = require('mv');
 var Request = require('./request');
 
-const tmp_folder = path.join(os.tmpDir(), 'google-font-installer');
+const tmp_folder = path.join(os.tmpdir(), 'google-font-installer');
 
 function SystemFont() {}
 


### PR DESCRIPTION
tmpdir() is now used instead of tmpDir. Fixes warning during runtime.